### PR TITLE
fix: updated backend logic for creating comment to return blog object…

### DIFF
--- a/zodValidations/auth/constant.ts
+++ b/zodValidations/auth/constant.ts
@@ -85,7 +85,7 @@ export const checkContentWordLim = (blogContent:string):string=>{
 }
 
 export const newCommentFormSchema = z.object({
-  comment: z.string().min(2, {
+  comment: z.string().max(250).min(2, {
     message: "Your comment cannot be less than 2 characters"
   })
 })


### PR DESCRIPTION
This PR does the following:
- Adds the commenter's name and date comment was added to the comment card.
- Displays comments list from the data returned on successful comment submission. This removes the need for single page reload, thereby, reducing the number of backend API calls.