### PR TITLE
fix: navbar mobile menu and discover page hero fixes

### DIFF
--- a/components/Profile/DeleteAccount.tsx
+++ b/components/Profile/DeleteAccount.tsx
@@ -16,7 +16,6 @@ const DeleteAccount = () => {
   const handleDeleteAccount = async () => {
     try {
       const res = await mutateAsync();
-      console.log(res);
       if (!isPending && res.message) {
         toasterAlert(res.message);
         cookies.remove("token");

--- a/components/Profile/EditProfile.tsx
+++ b/components/Profile/EditProfile.tsx
@@ -65,22 +65,10 @@ const EditProfile = () => {
     },
   });
 
-  console.log(data);
-
   const onSubmit = async (values: EditProfileFormData) => {
     // console.log("The values are", values);
     try {
       const formData = new FormData();
-      // values.firstName !== ""
-      //   ? formData.set("firstName", values.firstName)
-      //   : "";
-      // values.lastName !== "" ? formData.set("lastName", values.lastName) : "";
-      // values.email !== "" ? formData.set("email", values.email) : "";
-      // profileImage !== "" && !values.removeProfilePic
-      //   ? formData.set("authorImg", profileImage)
-      //   : values.removeProfilePic
-      //   ? formData.set("authorImg", "")
-      //   : "";
 
       if (values.firstName !== "") {
         formData.set("firstName", values.firstName);
@@ -97,13 +85,6 @@ const EditProfile = () => {
       if (!values.removeProfilePic && profileImage !== "") {
         formData.set("authorImg", profileImage);
       }
-      // if (profileImage !== "" && values.removeProfilePic === false) {
-      //   formData.set("articleImg", profileImage);
-      // } else if (values.removeProfilePic === true) {
-      //   formData.set("authorImg", "");
-      // }
-      console.log(values.removeProfilePic);
-      console.log(...formData);
 
       const res = await mutateAsync(formData);
 

--- a/components/QuillCreateBlog/QuilCreateBlogPage.tsx
+++ b/components/QuillCreateBlog/QuilCreateBlogPage.tsx
@@ -7,19 +7,25 @@ import Link from "next/link";
 import Loading from "../common/Loader";
 import QuillCreateBlogForm from "./QuillCreateBlogForm";
 import { AppContext } from "@/context/AppContext";
-import { CircleXIcon, InfoIcon } from "lucide-react";
 import BlogContentTextColorWarning from "../modals/BlogContentTextColorWarning";
+import { InfoIcon } from "lucide-react";
 
 const QuillCreateBlogPage = () => {
   const [homePageLoading, setHomePageLoading] = useState<boolean>(false);
-  const [contentTextColorWarning, setContentTextColorWarning] =
-    useState<boolean>(true);
-  const { dispatch } = useContext(AppContext);
+
+  const { dispatch, state } = useContext(AppContext);
   const handleClickBack = () => {
     setHomePageLoading(true);
     dispatch({
       type: "BLOGCONTENT_WARN",
       payload: "No",
+    });
+  };
+
+  const handleInfoClick = () => {
+    dispatch({
+      type: "CONTENT_TEXT_COLOR_WARNING",
+      payload: true,
     });
   };
 
@@ -39,27 +45,15 @@ const QuillCreateBlogPage = () => {
             {" "}
             Welcome to create blog post dashboard
           </p>
-          <div className="flex content-center justify-center absolute top-22 right-4 h-10 w-10 p-1 ">
-            {contentTextColorWarning ? (
-              <CircleXIcon
-                size={50}
-                onClick={() => setContentTextColorWarning(false)}
-              />
-            ) : (
-              <InfoIcon
-                onClick={() => setContentTextColorWarning(true)}
-                size={50}
-              />
-            )}
+          <div className="flex content-center justify-center cursor-pointer absolute top-22 right-4 h-10 w-10 p-1 ">
+            <InfoIcon onClick={handleInfoClick} size={50} />
           </div>
-          {contentTextColorWarning && <BlogContentTextColorWarning />}
+          {state.contentTextColorWarning && <BlogContentTextColorWarning />}
         </div>
 
         <MaxWidth className="h-fit py-10 w-3/4 max-lg:w-[88%] max-md:w-[95%] justify-center relative -top-24 bg-white dark:bg-slate-900 border rounded-lg shadow-md">
           <div className="w-9/10 max-lg:w-[100%]  justify-center mx-auto">
             <QuillCreateBlogForm />
-
-            {/* <div className="justify-center flex w-full mx-auto"></div> */}
 
             <Link href={"/"} className="justify-center flex">
               <Button

--- a/components/QuillCreateBlog/QuillCreateBlogForm.tsx
+++ b/components/QuillCreateBlog/QuillCreateBlogForm.tsx
@@ -117,9 +117,6 @@ const QuillCreateBlogForm = () => {
       formData.set("category", values.category);
       formData.set("articleImg", file);
 
-      console.log(...formData);
-      // console.log(values.blogContent);
-      // console.log(checkContentWordLim(values.blogContent));
       if (checkContentWordLim(values.blogContent) === "enough") {
         dispatch({
           type: "BLOGCONTENT_WARN",

--- a/components/QuillEditBlogForm/QuillEditBlogForm.tsx
+++ b/components/QuillEditBlogForm/QuillEditBlogForm.tsx
@@ -112,15 +112,6 @@ const QuillEditBlogForm = () => {
 
     try {
       const formData = new FormData();
-      // values.title !== "" ? formData.set("title", values.title) : "";
-      // values.blogContent !== ""
-      //   ? formData.set("blogContent", values.blogContent)
-      //   : "";
-      // values.blogContent !== ""
-      //   ? formData.set("readTime", blogReadTime(values.blogContent))
-      //   : "";
-      // values.category !== "" ? formData.set("category", values.category) : "";
-      // values.articleImg !== "" ? formData.set("articleImg", file) : "";
 
       if (values.title !== "") {
         formData.set("title", values.title);

--- a/components/Seacrh/ExploreAuthors.tsx
+++ b/components/Seacrh/ExploreAuthors.tsx
@@ -22,7 +22,7 @@ const ExploreAuthors = () => {
 
   useEffect(() => {
     if (isSuccess && data) {
-      console.log(data);
+      // console.log(data);
       setBlogAuthors(data.authors);
       setNumberOfAuthors(data.authors.length);
     }

--- a/components/Seacrh/SearchHero.tsx
+++ b/components/Seacrh/SearchHero.tsx
@@ -20,11 +20,11 @@ const SearchHero = () => {
         className="object-cover w-full"
       />
 
-      <div className="absolute -bottom-24 left-1/2 -translate-x-1/2 p-[64px] max-md:p-[10px] lg:w-[80%] max-lg:w-[85%] max-md:h-[50] max-w-[1272px] bg-white rounded-3xl shadow-lg dark:shadow-gray-600 flex flex-col justify-center items-center gap-y-8 border dark:bg-black">
+      <div className="absolute -bottom-24 left-1/2 -translate-x-1/2 p-[64px] max-md:p-[10px] lg:w-[80%] max-lg:w-[85%]  max-w-[1272px] bg-white rounded-3xl shadow-lg dark:shadow-gray-600 flex flex-col justify-center items-center gap-y-8 border dark:bg-black">
         <div className="flex flex-col gap-y-3 items-center ">
           <h3
             className={cn(
-              "font-semibold text-gray-800 text-5xl max-md:text-lg dark:text-white",
+              "font-semibold text-gray-800 text-5xl max-md:text-lg max-md:mt-[20px] dark:text-white",
               poppins.className
             )}
           >

--- a/components/common/NavBar.tsx
+++ b/components/common/NavBar.tsx
@@ -7,7 +7,6 @@ import Image from "next/image";
 import Cookies from "universal-cookie";
 import {
   ChevronDown,
-  CircleXIcon,
   LoaderCircle,
   Menu,
   // MonitorCog,
@@ -46,20 +45,15 @@ import { useGetAUser } from "@/hooks/authors/useGetAUser";
 const cookies = new Cookies(null, { path: "/" });
 
 const NavBar = () => {
-  // const { state } = useContext(AppContext);
-
   const [activeTab, setActiveTab] = useState<string | null>(null);
   const [token, setToken] = useState<string | undefined>("");
-  // const [gettingToken, setGettingToken] = useState<boolean>(true);
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [signUpIsLoading, setSignUpIsLoading] = useState<boolean>(false);
   const [isLoggingOut, setIsLoggingOut] = useState<boolean>(false);
-  const [toggleMenu, setToggleMenu] = useState<boolean>(false);
 
   const { theme, setTheme } = useTheme();
 
-  // const baseUrl = process.env.NEXT_PUBLIC_UPLOAD_URL;
   const { data, isLoading: getUserIsLoading } = useGetAUser();
 
   const pathname = usePathname();
@@ -78,17 +72,11 @@ const NavBar = () => {
       if (typeof window !== "undefined") {
         const token = await cookies.get("token");
         setToken(token);
-        // setGettingToken(false);
       }
     };
 
     getToken();
   }, []);
-
-  // useEffect((e:Event)=>{
-  //   const closeDropDown = e=>{setToggleMenu(false)}
-  //   document.body.addEventListener('click', closeDropDown)
-  // },[])
 
   const userName = () => {
     if (!getUserIsLoading && data) {
@@ -171,57 +159,45 @@ const NavBar = () => {
             </div>
 
             <div className="hidden max-md:block">
-              {!toggleMenu ? (
-                <Menu className="h-full" onClick={() => setToggleMenu(true)} />
-              ) : (
-                <CircleXIcon
-                  className="h-full"
-                  onClick={() => setToggleMenu(false)}
-                />
-              )}
-              {toggleMenu && (
-                <div className="flex flex-col min-w-24 mt-2 h-fit border bg-white dark:bg-black rounded-sm shadow-sm">
-                  <div className="flex flex-col divide-y-2">
-                    {NavBarMenuList.map((menu) => (
-                      <Link
-                        href={
-                          menu.split(" ")[0].toLowerCase() !== "home"
-                            ? `/${menu.split(" ")[0].toLowerCase()}`
-                            : "/"
-                        }
-                        key={menu}
-                        className="p-2 text-md"
-                        onClick={() => setToggleMenu(false)}
-                      >
-                        {menu}
-                      </Link>
-                    ))}
-                    <div className=" cursor-pointer h-full flex content-center">
+              <DropdownMenu>
+                <DropdownMenuTrigger className="flex h-full content-center">
+                  <Menu className="h-full" />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent className="w-38 z-[100] mr-4 mt-3">
+                  <DropdownMenuGroup>
+                    <DropdownMenuItem className="cursor-pointer">
+                      <Link href={"/"}>Home</Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem className="cursor-pointer">
+                      <Link href={"/discover"}>Discover</Link>
+                    </DropdownMenuItem>
+
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem className="cursor-pointer h-full">
                       {theme === "light" ? (
                         <button
                           onClick={() => {
                             setTheme("dark");
-                            setToggleMenu(false);
                           }}
-                          className=" py-2 pl-2 mr-1 gap-1 flex flex-nowrap"
+                          className="flex gap-1 content-center"
                         >
-                          Dark Mode <Moon />
+                          Dark Mode <Moon className="m-1" />
                         </button>
                       ) : (
                         <button
                           onClick={() => {
                             setTheme("light");
-                            setToggleMenu(false);
                           }}
-                          className=" py-2 pl-2 mr-1 gap-1 flex flex-nowrap"
+                          className="flex gap-1 content-center"
                         >
-                          Light Mode <Sun />
+                          Light Mode <Sun className="m-1" />
                         </button>
                       )}
-                    </div>
-                  </div>
-                </div>
-              )}
+                    </DropdownMenuItem>
+                  </DropdownMenuGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
           </div>
 

--- a/components/modals/BlogContentTextColorWarning.tsx
+++ b/components/modals/BlogContentTextColorWarning.tsx
@@ -1,11 +1,28 @@
 "use client";
 
-import React from "react";
+import { AppContext } from "@/context/AppContext";
+import { CircleXIcon } from "lucide-react";
+import React, { useContext } from "react";
 
 const BlogContentTextColorWarning = () => {
+  const { dispatch } = useContext(AppContext);
+
+  const handleCloseModal = () => {
+    dispatch({
+      type: "CONTENT_TEXT_COLOR_WARNING",
+      payload: false,
+    });
+  };
   return (
-    <div className="w-full flex  justify-end absolute z-99">
-      <div className="flex flex-col w-150 bg-white dark:bg-black/99 h-fit rounded-2xl p-2 content-center shadow-2xl mt-4 mr-6 justify-end gap-1 text-md">
+    <div className="w-full h-full flex bg-black/90 fixed top-15 right-0  justify-center content-center z-99">
+      <div className="flex flex-col w-150 max-md:w-80 bg-white dark:bg-black/99 dark:shadow-slate-700 h-fit rounded-2xl p-6 content-center shadow-2xl my-auto gap-1 text-md">
+        <div className="flex justify-end content-center w-full relative -mt-5 -mr-2 mb-2 h-10  p-1 ">
+          <CircleXIcon
+            className="cursor-pointer"
+            size={38}
+            onClick={handleCloseModal}
+          />
+        </div>
         <p className="">
           The blog content text editor is color sensitive! Please if you copy
           text from a dark background source or a webpage, there is a high

--- a/context/AppContext.jsx
+++ b/context/AppContext.jsx
@@ -53,6 +53,12 @@ export const AppReducer = (state, action) => {
         profileData: action.payload,
       };
 
+    case "CONTENT_TEXT_COLOR_WARNING":
+      return {
+        ...state,
+        contentTextColorWarning: action.payload,
+      };
+
     default:
       return state;
   }
@@ -67,6 +73,7 @@ const initialState = {
   blogContentWarn: "No",
   canLogin: false,
   profileData: null,
+  contentTextColorWarning: true,
 };
 
 //create the context. This is the thing that the components import and use to get the state


### PR DESCRIPTION
This PR achieves the following:
- switches navbar's menu dropdown to shadcn's dropdown, preventing resizing of navbar element's boxes on click of this icon button. 
- Switches content text color warning message to full modal on create-blog page. AppContext's state controls opening and closing of modal. 
- Adjusts the width of search hero card to correct the overflowing of the content of this card on mobile view. 
- Cleans out console.logs from components in the project.